### PR TITLE
Version/v0.2.1

### DIFF
--- a/aerospike_rest/__init__.py
+++ b/aerospike_rest/__init__.py
@@ -1,5 +1,5 @@
-NAME = 'aerospike-rest'
-VERSION = (0, 2, 0)
+NAME = "aerospike-rest"
+VERSION = (0, 2, 1)
 
 
 def get_version():

--- a/aerospike_rest/exceptions.py
+++ b/aerospike_rest/exceptions.py
@@ -1,13 +1,13 @@
+import json
+
 
 class AerospikeRestApiError(Exception):
     def __init__(self, http_response, status_code):
-        self.message = http_response['message']
-        self.in_doubt = http_response['inDoubt']
         self.status_code = status_code
-        self.code = http_response['internalErrorCode']
-    
+        self.response = json.dumps(http_response)
+
     def __str__(self):
-        return "{} {}".format(self.status_code, self.message)
+        return "{} {}".format(self.status_code, self.response)
 
 
 # error codes from Java client:


### PR DESCRIPTION
Non-standard restclient responses are possible (see below), when they occur they're not being logged due to keys the error handling code assumes will be present:

```{'timestamp': 1644796894680, 'status': 500, 'error': 'Internal Server Error', 'path': '/v1/operate/amspush/availability/001f200001iFXrOAAW:aws:us-west-2:stage:maddie:20220207/'}```

This change exposes the entirety of the response and avoids any issues with assuming specific keys will be present.